### PR TITLE
Keys changed rebased persistent

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -17,6 +17,7 @@ packages:
          ./plugins/hls-retrie-plugin
          ./plugins/hls-haddock-comments-plugin
          ./plugins/hls-splice-plugin
+         ../shake
 tests: true
 
 package *

--- a/ghcide/session-loader/Development/IDE/Session.hs
+++ b/ghcide/session-loader/Development/IDE/Session.hs
@@ -397,7 +397,7 @@ loadSessionWithOptions SessionLoadingOptions{..} dir = do
 
           -- Invalidate all the existing GhcSession build nodes by restarting the Shake session
           invalidateShakeCache
-          restartShakeSession []
+          restartShakeSession Nothing []
 
           -- Typecheck all files in the project on startup
           checkProject <- getCheckProject

--- a/ghcide/src/Development/IDE.hs
+++ b/ghcide/src/Development/IDE.hs
@@ -15,7 +15,7 @@ import           Development.IDE.Core.FileExists       as X (getFileExists)
 import           Development.IDE.Core.FileStore        as X (getFileContents)
 import           Development.IDE.Core.IdeConfiguration as X (IdeConfiguration (..),
                                                              isWorkspaceFile)
-import           Development.IDE.Core.OfInterest       as X (getFilesOfInterest)
+import           Development.IDE.Core.OfInterest       as X (getFilesOfInterestUntracked)
 import           Development.IDE.Core.RuleTypes        as X
 import           Development.IDE.Core.Rules            as X (IsHiFileStable (..),
                                                              getClientConfigAction,
@@ -44,6 +44,8 @@ import           Development.IDE.Core.Shake            as X (FastResult (..),
                                                              use_, uses, uses_)
 import           Development.IDE.GHC.Error             as X
 import           Development.IDE.GHC.Util              as X
+import           Development.IDE.Graph                 as X (Action, RuleResult,
+                                                             Rules, action)
 import           Development.IDE.Plugin                as X
 import           Development.IDE.Types.Diagnostics     as X
 import           Development.IDE.Types.HscEnvEq        as X (HscEnvEq (..),
@@ -51,5 +53,3 @@ import           Development.IDE.Types.HscEnvEq        as X (HscEnvEq (..),
                                                              hscEnvWithImportPaths)
 import           Development.IDE.Types.Location        as X
 import           Development.IDE.Types.Logger          as X
-import           Development.IDE.Graph                     as X (Action, RuleResult,
-                                                             Rules, action)

--- a/ghcide/src/Development/IDE/Core/Actions.hs
+++ b/ghcide/src/Development/IDE/Core/Actions.hs
@@ -28,9 +28,9 @@ import           Development.IDE.GHC.Compat           hiding (TargetFile,
                                                        parseModule,
                                                        typecheckModule,
                                                        writeHieFile)
+import           Development.IDE.Graph
 import qualified Development.IDE.Spans.AtPoint        as AtPoint
 import           Development.IDE.Types.Location
-import           Development.IDE.Graph
 import qualified HieDb
 import           Language.LSP.Types                   (DocumentHighlight (..),
                                                        SymbolInformation (..))
@@ -116,7 +116,7 @@ highlightAtPoint file pos = runMaybeT $ do
 refsAtPoint :: NormalizedFilePath -> Position -> Action [Location]
 refsAtPoint file pos = do
     ShakeExtras{hiedb} <- getShakeExtras
-    fs <- HM.keys <$> getFilesOfInterest
+    fs <- HM.keys <$> getFilesOfInterestUntracked
     asts <- HM.fromList . mapMaybe sequence . zip fs <$> usesWithStale GetHieAst fs
     AtPoint.referencesAtPoint hiedb file pos (AtPoint.FOIReferences asts)
 

--- a/ghcide/src/Development/IDE/Core/FileStore.hs
+++ b/ghcide/src/Development/IDE/Core/FileStore.hs
@@ -160,8 +160,7 @@ isInterface f = takeExtension (fromNormalizedFilePath f) `elem` [".hi", ".hi-boo
 -- | Reset the GetModificationTime state of interface files
 resetInterfaceStore :: ShakeExtras -> NormalizedFilePath -> IO ()
 resetInterfaceStore state f = do
-    deleteValue state (GetModificationTime_ True) f
-    deleteValue state (GetModificationTime_ False) f
+    deleteValue state GetModificationTime f
 
 -- | Reset the GetModificationTime state of watched files
 resetFileStore :: IdeState -> [FileEvent] -> IO ()
@@ -177,8 +176,7 @@ resetFileStore ideState changes = mask $ \_ -> do
               , nfp <- toNormalizedFilePath f
               , not $ HM.member nfp fois
               -> do
-                    deleteValue (shakeExtras ideState) (GetModificationTime_ True) nfp
-                    deleteValue (shakeExtras ideState) (GetModificationTime_ False) nfp
+                    deleteValue (shakeExtras ideState) GetModificationTime nfp
             _ -> pure ()
 
 

--- a/ghcide/src/Development/IDE/Core/OfInterest.hs
+++ b/ghcide/src/Development/IDE/Core/OfInterest.hs
@@ -27,7 +27,6 @@ import           Development.IDE.Graph
 import           Control.Monad.Trans.Class
 import           Control.Monad.Trans.Maybe
 import qualified Data.ByteString                              as BS
-import           Data.Foldable                                (toList)
 import           Data.List.Extra                              (nubOrd)
 import           Data.Maybe                                   (catMaybes)
 import           Development.IDE.Core.ProgressReporting
@@ -80,14 +79,14 @@ addFileOfInterest state f v = do
     OfInterestVar var <- getIdeGlobalState state
     files <- modifyVar' var $ HashMap.insert f v
     recordDirtyKeys (shakeExtras state) IsFileOfInterest [f]
-    logDebug (ideLogger state) $ "Set files of interest to: " <> T.pack (show $ toList files)
+    logDebug (ideLogger state) $ "Set files of interest to: " <> T.pack (show files)
 
 deleteFileOfInterest :: IdeState -> NormalizedFilePath -> IO ()
 deleteFileOfInterest state f = do
     OfInterestVar var <- getIdeGlobalState state
     files <- modifyVar' var $ HashMap.delete f
     recordDirtyKeys (shakeExtras state) IsFileOfInterest [f]
-    logDebug (ideLogger state) $ "Set files of interest to: " <> T.pack (show $ toList files)
+    logDebug (ideLogger state) $ "Set files of interest to: " <> T.pack (show files)
 
 
 -- | Typecheck all the files of interest.

--- a/ghcide/src/Development/IDE/Core/OfInterest.hs
+++ b/ghcide/src/Development/IDE/Core/OfInterest.hs
@@ -74,7 +74,9 @@ modifyFilesOfInterest
   -> IO ()
 modifyFilesOfInterest state f = do
     OfInterestVar var <- getIdeGlobalState state
+    files0 <- readVar var
     files <- modifyVar' var f
+    when (files /= files0) $ recordDirtyKeys (shakeExtras state) GetFilesOfInterest [emptyFilePath]
     logDebug (ideLogger state) $ "Set files of interest to: " <> T.pack (show $ HashMap.toList files)
 
 -- | Typecheck all the files of interest.

--- a/ghcide/src/Development/IDE/Core/RuleTypes.hs
+++ b/ghcide/src/Development/IDE/Core/RuleTypes.hs
@@ -40,7 +40,6 @@ import           HscTypes                                     (HomeModInfo,
 import qualified Data.Binary                                  as B
 import           Data.ByteString                              (ByteString)
 import qualified Data.ByteString.Lazy                         as LBS
-import           Data.HashMap.Strict                          (HashMap)
 import           Data.Text                                    (Text)
 import           Data.Time
 import           Development.IDE.Import.FindImports           (ArtifactsLocation)
@@ -354,8 +353,6 @@ type instance RuleResult GetModSummary = ModSummaryResult
 -- | Generate a ModSummary with the timestamps and preprocessed content elided, for more successful early cutoff
 type instance RuleResult GetModSummaryWithoutTimestamps = ModSummaryResult
 
-type instance RuleResult GetFilesOfInterest = HashMap NormalizedFilePath FileOfInterestStatus
-
 data GetParsedModule = GetParsedModule
     deriving (Eq, Show, Typeable, Generic)
 instance Hashable GetParsedModule
@@ -512,12 +509,6 @@ data GhcSessionIO = GhcSessionIO deriving (Eq, Show, Typeable, Generic)
 instance Hashable GhcSessionIO
 instance NFData   GhcSessionIO
 instance Binary   GhcSessionIO
-
-data GetFilesOfInterest = GetFilesOfInterest
-    deriving (Eq, Show, Typeable, Generic)
-instance Hashable GetFilesOfInterest
-instance NFData   GetFilesOfInterest
-instance Binary   GetFilesOfInterest
 
 makeLensesWith
     (lensRules & lensField .~ mappingNamer (pure . (++ "L")))

--- a/ghcide/src/Development/IDE/LSP/Notifications.hs
+++ b/ghcide/src/Development/IDE/LSP/Notifications.hs
@@ -36,6 +36,8 @@ import           Development.IDE.Core.FileStore        (resetFileStore,
                                                         setSomethingModified,
                                                         typecheckParents)
 import           Development.IDE.Core.OfInterest
+import           Development.IDE.Core.RuleTypes        (GetClientSettings (..))
+import           Development.IDE.Types.Shake           (toKey)
 import           Ide.Plugin.Config                     (CheckParents (CheckOnClose))
 import           Ide.Types
 
@@ -86,7 +88,7 @@ descriptor plId = (defaultPluginDescriptor plId) { pluginNotificationHandlers = 
         logDebug (ideLogger ide) $ "Watched file events: " <> msg
         modifyFileExists ide fileEvents
         resetFileStore ide fileEvents
-        setSomethingModified ide
+        setSomethingModified ide []
 
   , mkPluginNotificationHandler LSP.SWorkspaceDidChangeWorkspaceFolders $
       \ide _ (DidChangeWorkspaceFoldersParams events) -> liftIO $ do
@@ -101,7 +103,7 @@ descriptor plId = (defaultPluginDescriptor plId) { pluginNotificationHandlers = 
         let msg = Text.pack $ show cfg
         logDebug (ideLogger ide) $ "Configuration changed: " <> msg
         modifyClientSettings ide (const $ Just cfg)
-        setSomethingModified ide
+        setSomethingModified ide [toKey GetClientSettings emptyFilePath ]
 
   , mkPluginNotificationHandler LSP.SInitialized $ \ide _ _ -> do
       --------- Initialize Shake session --------------------------------------------------------------------

--- a/ghcide/src/Development/IDE/Types/Options.hs
+++ b/ghcide/src/Development/IDE/Types/Options.hs
@@ -22,8 +22,8 @@ module Development.IDE.Types.Options
 import qualified Data.Text                         as T
 import           Data.Typeable
 import           Development.IDE.Core.RuleTypes
-import           Development.IDE.Types.Diagnostics
 import           Development.IDE.Graph
+import           Development.IDE.Types.Diagnostics
 import           GHC                               hiding (parseModule,
                                                     typecheckModule)
 import           GhcPlugins                        as GHC hiding (fst3, (<>))
@@ -80,6 +80,8 @@ data IdeOptions = IdeOptions
   , optSkipProgress       :: forall a. Typeable a => a -> Bool
       -- ^ Predicate to select which rule keys to exclude from progress reporting.
   , optProgressStyle      :: ProgressReportingStyle
+  , optRunSubset          :: Bool
+      -- ^ Experimental feature to re-run only the subset of the Shake graph that has changed
   }
 
 optShakeFiles :: IdeOptions -> Maybe FilePath
@@ -141,6 +143,7 @@ defaultIdeOptions session = IdeOptions
     ,optCustomDynFlags = id
     ,optSkipProgress = defaultSkipProgress
     ,optProgressStyle = Explicit
+    ,optRunSubset = False
     }
 
 defaultSkipProgress :: Typeable a => a -> Bool

--- a/ghcide/src/Development/IDE/Types/Shake.hs
+++ b/ghcide/src/Development/IDE/Types/Shake.hs
@@ -8,11 +8,12 @@ module Development.IDE.Types.Shake
     ValueWithDiagnostics (..),
     Values,
     Key (..),
+    SomeShakeValue,
     BadDependency (..),
     ShakeValue(..),
     currentValue,
     isBadDependency,
-  toShakeValue,encodeShakeValue,decodeShakeValue)
+  toShakeValue,encodeShakeValue,decodeShakeValue,toKey,toNoFileKey)
 where
 
 import           Control.DeepSeq
@@ -24,11 +25,13 @@ import           Data.Hashable
 import           Data.Typeable
 import           Data.Vector                          (Vector)
 import           Development.IDE.Core.PositionMapping
+import           Development.IDE.Graph                (RuleResult,
+                                                       ShakeException (shakeExceptionInner))
+import qualified Development.IDE.Graph                as Shake
+import           Development.IDE.Graph.Classes
+import           Development.IDE.Graph.Database       (SomeShakeValue (..))
 import           Development.IDE.Types.Diagnostics
 import           Development.IDE.Types.Location
-import           Development.IDE.Graph                    (RuleResult,
-                                                       ShakeException (shakeExceptionInner))
-import           Development.IDE.Graph.Classes
 import           GHC.Generics
 import           Language.LSP.Types
 
@@ -54,7 +57,7 @@ data ValueWithDiagnostics
 type Values = HashMap (NormalizedFilePath, Key) ValueWithDiagnostics
 
 -- | Key type
-data Key = forall k . (Typeable k, Hashable k, Eq k, Show k) => Key k
+data Key = forall k . (Typeable k, Hashable k, Eq k, NFData k, Show k) => Key k
 
 instance Show Key where
   show (Key k) = show k
@@ -64,7 +67,14 @@ instance Eq Key where
                      | otherwise = False
 
 instance Hashable Key where
-    hashWithSalt salt (Key key) = hashWithSalt salt (typeOf key, key)
+    hashWithSalt salt (Key key) = hashWithSalt salt key
+
+instance Binary Key where
+    get = error "not really"
+    put _ = error "not really"
+
+instance NFData Key where
+    rnf (Key k) = rnf k
 
 -- | When we depend on something that reported an error, and we fail as a direct result, throw BadDependency
 --   which short-circuits the rest of the action
@@ -76,6 +86,13 @@ isBadDependency x
     | Just (x :: ShakeException) <- fromException x = isBadDependency $ shakeExceptionInner x
     | Just (_ :: BadDependency) <- fromException x = True
     | otherwise = False
+
+
+toKey :: Shake.ShakeValue k => k -> NormalizedFilePath -> SomeShakeValue
+toKey = (SomeShakeValue .) . curry Q
+
+toNoFileKey :: (Show k, Typeable k, Eq k, Hashable k, Binary k, NFData k) => k -> SomeShakeValue
+toNoFileKey k = toKey k emptyFilePath
 
 newtype Q k = Q (k, NormalizedFilePath)
     deriving newtype (Eq, Hashable, NFData)

--- a/hls-graph/src/Development/IDE/Graph/Database.hs
+++ b/hls-graph/src/Development/IDE/Graph/Database.hs
@@ -1,8 +1,9 @@
 
 module Development.IDE.Graph.Database(
     Shake.ShakeDatabase,
+    Shake.SomeShakeValue(..),
     shakeOpenDatabase,
-    shakeRunDatabase,
+    shakeRunDatabaseForKeys,
     Shake.shakeProfileDatabase,
     ) where
 
@@ -14,5 +15,9 @@ import Development.IDE.Graph.Internal.Rules
 shakeOpenDatabase :: ShakeOptions -> Rules () -> IO (IO Shake.ShakeDatabase, IO ())
 shakeOpenDatabase a b = Shake.shakeOpenDatabase (fromShakeOptions a) (fromRules b)
 
-shakeRunDatabase :: Shake.ShakeDatabase -> [Action a] -> IO ([a], [IO ()])
-shakeRunDatabase a b = Shake.shakeRunDatabase a (map fromAction b)
+shakeRunDatabaseForKeys
+    :: Maybe [Shake.SomeShakeValue]       -- ^ Set of keys changed since last run
+    -> Shake.ShakeDatabase
+    -> [Action a]
+    -> IO ([a], [IO ()])
+shakeRunDatabaseForKeys keys a b = Shake.shakeRunDatabaseForKeys keys a (map fromAction b)

--- a/plugins/default/src/Ide/Plugin/Example.hs
+++ b/plugins/default/src/Ide/Plugin/Example.hs
@@ -77,7 +77,7 @@ exampleRules = do
     return ([diag], Just ())
 
   action $ do
-    files <- getFilesOfInterest
+    files <- getFilesOfInterestUntracked
     void $ uses Example $ Map.keys files
 
 mkDiag :: NormalizedFilePath

--- a/plugins/default/src/Ide/Plugin/Example2.hs
+++ b/plugins/default/src/Ide/Plugin/Example2.hs
@@ -75,7 +75,7 @@ exampleRules = do
     return ([diag], Just ())
 
   action $ do
-    files <- getFilesOfInterest
+    files <- getFilesOfInterestUntracked
     void $ uses Example2 $ Map.keys files
 
 mkDiag :: NormalizedFilePath

--- a/plugins/hls-hlint-plugin/src/Ide/Plugin/Hlint.hs
+++ b/plugins/hls-hlint-plugin/src/Ide/Plugin/Hlint.hs
@@ -120,8 +120,7 @@ type instance RuleResult GetHlintDiagnostics = ()
 
 -- | Hlint rules to generate file diagnostics based on hlint hints
 -- | This rule is recomputed when:
--- | - The files of interest have changed via `getFilesOfInterest`
--- | - One of those files has been edited via
+-- | - A file has been edited via
 -- |    - `getIdeas` -> `getParsedModule` in any case
 -- |    - `getIdeas` -> `getFileContents` if the hls ghc does not match the hlint default ghc
 -- | - The client settings have changed, to honour the `hlintOn` setting, via `getClientConfigAction`
@@ -140,7 +139,7 @@ rules plugin = do
     liftIO $ argsSettings flags
 
   action $ do
-    files <- getFilesOfInterest
+    files <- getFilesOfInterestUntracked
     void $ uses GetHlintDiagnostics $ Map.keys files
 
   where

--- a/plugins/hls-tactics-plugin/src/Wingman/LanguageServer.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/LanguageServer.hs
@@ -26,7 +26,7 @@ import           Data.Set (Set)
 import qualified Data.Set as S
 import qualified Data.Text as T
 import           Data.Traversable
-import           Development.IDE (getFilesOfInterest, ShowDiagnostic (ShowDiag), srcSpanToRange)
+import           Development.IDE (getFilesOfInterestUntracked, ShowDiagnostic (ShowDiag), srcSpanToRange)
 import           Development.IDE (hscEnv)
 import           Development.IDE.Core.RuleTypes
 import           Development.IDE.Core.Rules (usePropertyAction)
@@ -518,7 +518,7 @@ wingmanRules plId = do
               )
 
   action $ do
-    files <- getFilesOfInterest
+    files <- getFilesOfInterestUntracked
     void $ uses WriteDiagnostics $ Map.keys files
 
 


### PR DESCRIPTION
Keep track of keys changed and include them in the call to `shakeRunDatabaseForKeys`, allowing for more efficient rebuilds. 

Requires a version of Shake extended with reverse dependency tracking - https://github.com/ndmitchell/shake/pull/802